### PR TITLE
Adds optional source param which overrides sketch-file in the config

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,7 +13,7 @@ var userAction = argv._[0];
 handleInput(userAction);
 
 function showHelp() {
-  console.log('usage:\njewelbots-autodev compile\njewelbots-autodev upload\njewelbots-autodev help');
+  console.log('usage:\njewelbots-autodev compile [sketch]\njewelbots-autodev upload [sketch]\njewelbots-autodev help');
 };
 
 function setup(callback) {
@@ -25,6 +25,11 @@ function setup(callback) {
       fs.readFile(configPath, function(error, file) {
         if (error) return callback(error);
         config = JSON.parse(file);
+        var source = argv._[1];
+        if (source != undefined) {
+          config['sketch-file'] = source;
+        }
+
         return callback(null, config);
       });
     } else {


### PR DESCRIPTION
With this change you can now pass the ino file as an optional param. Relative paths work (I tested this). 

Example:
```
gbmac:jb-autodev-test glennblock$ jewelbots-autodev compile test1.ino
compiling test1.ino...
Ts: 1481043093 - Running: GenerateBuildPathIfMissing
Ts: 1481043093 - Running: EnsureBuildPathExists
Ts: 1481043093 - Running: ContainerSetupHardwareToolsLibsSketchAndProps
Ts: 1481043093 - Running: AddAdditionalEntriesToContext
Ts: 1481043093 - Running: FailIfBuildPathEqualsSketchPath
Ts: 1481043093 - Running: HardwareLoader
Ts: 1481043093 - Running: PlatformKeysRewriteLoader
Ts: 1481043093 - Running: RewriteHardwareKeys
Ts: 1481043093 - Running: ToolsLoader
Ts: 1481043094 - Running: TargetBoardResolver
Ts: 1481043094 - Running: AddBuildBoardPropertyIfMissing
Ts: 1481043094 - Running: LibrariesLoader
Ts: 1481043094 - Running: SketchLoader
Ts: 1481043094 - Running: SetupBuildProperties
Ts: 1481043094 - Running: LoadVIDPIDSpecificProperties
Ts: 1481043094 - Running: SetCustomBuildProperties
Ts: 1481043094 - Running: AddMissingBuildPropertiesFromParentPlatformTxtFiles
Ts: 1481043094 - Running: ContainerBuildOptions
Ts: 1481043094 - Running: CreateBuildOptionsMap
Ts: 1481043094 - Running: LoadPreviousBuildOptionsMap
Ts: 1481043094 - Running: WipeoutBuildPathIfBuildOptionsChanged
Ts: 1481043094 - Running: StoreBuildOptionsMap
Ts: 1481043094 - Running: WarnAboutPlatformRewrites
Ts: 1481043094 - Running: RecipeByPrefixSuffixRunner
Looking for recipes like recipe.hooks.prebuild*.pattern
Ts: 1481043094 - Running: ContainerMergeCopySketchFiles
Ts: 1481043094 - Running: SketchSourceMerger
Ts: 1481043094 - Running: SketchSaver
Ts: 1481043094 - Running: AdditionalSketchFilesCopier
Ts: 1481043094 - Running: loggerAction
Ts: 1481043094 - Running: ContainerFindIncludes
Ts: 1481043094 - Running: GCCPreprocRunnerForDiscoveringIncludes
Ts: 1481043094 - Running: IncludesFinderWithRegExp
Ts: 1481043094 - Running: GCCPreprocRunner
Ts: 1481043094 - Running: PrintUsedAndNotUsedLibraries
Ts: 1481043094 - Running: PrintUsedLibrariesIfVerbose
done.
```

